### PR TITLE
Remove scheduleDeferredCallback and its associated methods from the hostconfig ...

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1051,14 +1051,14 @@
       "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
     },
     "react-reconciler": {
-      "version": "0.20.4",
-      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.20.4.tgz",
-      "integrity": "sha512-kxERc4H32zV2lXMg/iMiwQHOtyqf15qojvkcZ5Ja2CPkjVohHw9k70pdDBwrnQhLVetUJBSYyqU3yqrlVTOajA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npm.taobao.org/react-reconciler/download/react-reconciler-0.21.0.tgz?cache=0&sync_timestamp=1565319381012&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Freact-reconciler%2Fdownload%2Freact-reconciler-0.21.0.tgz",
+      "integrity": "sha1-gYA0KrPIKV+GACWobQoDdCopTqc=",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "scheduler": "^0.15.0"
       }
     },
     "readable-stream": {
@@ -1135,9 +1135,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npm.taobao.org/scheduler/download/scheduler-0.15.0.tgz?cache=0&sync_timestamp=1565317903688&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fscheduler%2Fdownload%2Fscheduler-0.15.0.tgz",
+      "integrity": "sha1-a/z4D/hQsoD+1K7sxlE7wLTxf44=",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -14,20 +14,19 @@
     "dev": "tsc && qode ./dist/demo.js"
   },
   "dependencies": {
-    "react-reconciler": "^0.20.4"
+    "react-reconciler": "^0.21.0"
   },
   "peerDependencies": {
     "@nodegui/nodegui": "*",
     "@nodegui/qode": "*",
-    "react": "*"
+    "react": "16.9.0"
   },
   "devDependencies": {
     "@nodegui/nodegui": "^0.1.5",
     "@types/node": "^12.0.10",
     "@types/react-reconciler": "^0.18.0",
-    "@types/scheduler": "^0.12.1",
     "prettier": "^1.18.2",
-    "react": "^16.8.6",
+    "react": "^16.9.0",
     "typescript": "^3.5.2"
   }
 }

--- a/src/reconciler/index.ts
+++ b/src/reconciler/index.ts
@@ -215,16 +215,6 @@ const HostConfig: Reconciler.HostConfig<
       "unhideTextInstance called when platform doesnt have host level text"
     );
   },
-  // Fiber stuff I think
-  schedulePassiveEffects: scheduler.unstable_scheduleCallback, // For supporting useEffect hook,
-  cancelPassiveEffects: scheduler.unstable_cancelCallback, // For supporting useEffect hooks - cancellation
-  scheduleDeferredCallback: scheduler.unstable_scheduleCallback,
-  cancelDeferredCallback: scheduler.unstable_cancelCallback,
-  shouldYield: () => {
-    // When can renderer just rest and not do any work. Basically if shouldYield returns true the renderer would just sleep and pause.
-    // This method will be continuously polled by the reconciler to check if renderer should resume.
-    return false;
-  },
   scheduleTimeout: setTimeout,
   cancelTimeout: clearTimeout,
   noTimeout: -1,


### PR DESCRIPTION
Remove `scheduleDeferredCallback` and its associated methods from the hostconfig 

Since react v16.9 react-reconciler v0.21.0, these methods are imported directly from the scheduler by the reconciler and do not need to be manually specified from hostconfig.

https://github.com/facebook/react/commit/1e3b6192b54df20ac117a2af56afbe00ac9487b7
