### PR TITLE
Update link to examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Visit: https://react.nodegui.org for docs.
 
 **More screenshots?**
 
-[See examples](https://github.com/nodegui/react-nodegui/tree/master/examples/)
+[See examples](https://github.com/nodegui/examples/)
 
 ## Features
 


### PR DESCRIPTION
This PR updates the link to the sample apps from https://github.com/nodegui/react-nodegui/tree/master/examples/ to https://github.com/nodegui/examples/.