### PR TITLE
Support providing button titles through children

### DIFF
--- a/src/components/AbstractComponents/RNAbstractButton.ts
+++ b/src/components/AbstractComponents/RNAbstractButton.ts
@@ -26,6 +26,10 @@ import { QAbstractButton } from "@nodegui/nodegui";
 export interface AbstractButtonProps<Signals extends QAbstractButtonSignals>
   extends ViewProps<Signals> {
   /**
+   * Alternative method of providing the button text
+   */
+  children?: string;
+  /**
    * Sets the given text to the button. [QPushButton: setText](https://docs.nodegui.org/docs/api/QPushButton#buttonsettexttext)
    */
   text?: string;
@@ -45,6 +49,9 @@ export function setAbstractButtonProps<Signals extends QAbstractButtonSignals>(
   oldProps: AbstractButtonProps<Signals>
 ) {
   const setter: AbstractButtonProps<Signals> = {
+    set children(childrenText: string) {
+      widget.setText(childrenText);
+    },
     set text(buttonText: string) {
       widget.setText(buttonText);
     },
@@ -53,7 +60,7 @@ export function setAbstractButtonProps<Signals extends QAbstractButtonSignals>(
     },
     set iconSize(iconSize: QSize) {
       widget.setIconSize(iconSize);
-    }
+    },
   };
   Object.assign(setter, newProps);
   setViewProps(widget, newProps, oldProps);

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-import { Renderer, Text, ScrollArea, Window } from "./index";
+import { Renderer, Text, ScrollArea, Window, View, Button } from "./index";
 
 const App = () => {
   return (
     <Window>
-      <ScrollArea>
-        <Text>
-          {`
+      <View style="flex-direction: column">
+        <Button>Test</Button>
+        <ScrollArea>
+          <Text>
+            {`
             Contrary to popular belief, 
             Lorem Ipsum is not simply random text. 
             It has roots in a piece of classical Latin literature from 45 BC, 
@@ -42,8 +44,9 @@ const App = () => {
             sometimes on purpose (injected humour and the like).
 
         `}
-        </Text>
-      </ScrollArea>
+          </Text>
+        </ScrollArea>
+      </View>
     </Window>
   );
 };


### PR DESCRIPTION
Requiring the `text` prop to set the title of a `Button` isn't very idiomatic for React, and I commonly found myself making this mistake while testing. This simple change allows `Button`s to be created using either the `text` or `children` props.