### PR TITLE
Add textInteractionFlags to Text component

### DIFF
--- a/src/components/Text/RNText.ts
+++ b/src/components/Text/RNText.ts
@@ -1,4 +1,4 @@
-import { QLabel, NodeWidget, QLabelSignals } from '@nodegui/nodegui';
+import { QLabel, NodeWidget, QLabelSignals, TextInteractionFlag } from '@nodegui/nodegui';
 import { ViewProps, setViewProps } from '../View/RNView';
 import { RNWidget } from '../config';
 import { throwUnsupported } from '../../utils/helpers';
@@ -8,6 +8,7 @@ export interface TextProps extends ViewProps<QLabelSignals> {
   wordWrap?: boolean;
   scaledContents?: boolean;
   openExternalLinks?: boolean;
+  textInteractionFlags?: TextInteractionFlag;
 }
 
 /**
@@ -33,6 +34,9 @@ export const setTextProps = (
     set openExternalLinks(shouldOpenExternalLinks: boolean) {
       widget.setProperty('openExternalLinks', shouldOpenExternalLinks);
     },
+    set textInteractionFlags(interactionFlag: TextInteractionFlag){
+      widget.setProperty('textInteractionFlags', interactionFlag);
+    }
   };
   Object.assign(setter, newProps);
   setViewProps(widget, newProps, oldProps);

--- a/website/docs/api/interfaces/textprops.md
+++ b/website/docs/api/interfaces/textprops.md
@@ -207,7 +207,7 @@ ___
 
 ### `Optional` textInteractionFlags
 
-• **textInteractionFlags**? : *undefined | TextInteractionFlag*
+• **textInteractionFlags**? : *undefined | [TextInteractionFlag](https://docs.nodegui.org/docs/api/generated/enums/textinteractionflag)*
 
 Sets the widget's interaction flag
 ___

--- a/website/docs/api/interfaces/textprops.md
+++ b/website/docs/api/interfaces/textprops.md
@@ -35,6 +35,7 @@ sidebar_label: "TextProps"
 * [size](textprops.md#optional-size)
 * [style](textprops.md#optional-style)
 * [styleSheet](textprops.md#optional-stylesheet)
+* [textInteractionFlags](textprops.md#optional-textinteractionflags)
 * [visible](textprops.md#optional-visible)
 * [windowFlags](textprops.md#optional-windowflags)
 * [windowIcon](textprops.md#optional-windowicon)
@@ -202,6 +203,13 @@ ___
 
 Sets the property that holds the widget's style sheet. [QWidget: setStyleSheet](https://docs.nodegui.org/docs/api/NodeWidget#widgetsetstylesheetstylesheet)
 
+___
+
+### `Optional` textInteractionFlags
+
+• **textInteractionFlags**? : *undefined | TextInteractionFlag*
+
+Sets the widget's interaction flag
 ___
 
 ### `Optional` visible


### PR DESCRIPTION
The text interaction flag can now be given as a prop to the Text component.

As per issue https://github.com/nodegui/react-nodegui/issues/236.

Example usage:
`<Text textInteractionFlags={1}>You Can Select Me!</Text>`

Where 1 is from the Qt TextInteractionFlags enum: https://doc.qt.io/qt-5/qt.html#TextInteractionFlag-enum

Includes support for multiple flags using an `|` comparison, e.g. `textInteractionFlags={1|2}`

From testing: no16, TextEditable, does not appear to produce editable text as the Qt docs would indicate. However, this result can be achieved using a PlainTextEdit component if this functionality is really needed.

Docs are updated too.