### PR TITLE
Fix infinite recursion when using GridLayout

### DIFF
--- a/src/components/GridView/RNGridView.ts
+++ b/src/components/GridView/RNGridView.ts
@@ -80,7 +80,7 @@ export class RNGridView extends QWidget implements RNComponent {
   childRows: Array<DataWithOffset<RNGridRow>> = [];
 
   get layout() {
-    return this.layout;
+    return this._layout;
   }
 
   set layout(l: QGridLayout) {


### PR DESCRIPTION
`Maximum call stack size exceeded` error happens when using GridLayout. 

Fixes #348