### PR TITLE
Fix `Image.src` on Windows when it is a local file

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -6,8 +6,8 @@ export function throwUnsupported(instance: object) {
 
 export function isValidUrl(str: string) {
   try {
-    new URL(str);
-    return true;
+    const url = new URL(str);
+    return url.protocol === "http" || url.protocol === "https";
   } catch (_) {
     return false;
   }


### PR DESCRIPTION
`new URL("C:\path\filename.png")`
is treated as a valid URL, which it is not. `phin` subsequently tries
to fetch it, but `phin` and `centra` only supports http and https anyway.
Therefore `isValidUrl` will check also the protocol.