### PR TITLE
Fix `react` conflicting peer dependency with `react-reconciler`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "docs": "typedoc && node ./website/docs/scripts/fixdocs.js"
   },
   "dependencies": {
-    "@nodegui/nodegui": "^0.36.0",
+    "@nodegui/nodegui": "^0.40.1",
     "@types/react-reconciler": "^0.18.0",
     "phin": "3.5.1",
     "react-deep-force-update": "^2.1.3",
@@ -28,14 +28,15 @@
     "react-reconciler": "^0.25.1"
   },
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": "^16.14.0"
   },
   "devDependencies": {
-    "@types/node": "^16.6.1",
+    "@types/node": "^16.11.0",
+    "@types/react": "^16.14.0",
     "prettier": "^2.3.2",
-    "react": "^16.13.1",
+    "react": "^16.14.0",
     "typedoc": "^0.17.8",
     "typedoc-plugin-markdown": "^2.4.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.4"
   }
 }


### PR DESCRIPTION
Reverting back to `react@^16.x.x`. `react-reconciler` should be
updated separately so that it can safely be used with `react@17.x.x`.

`react-reconciler` should be version `0.26.2` and requires some refactoring.

When installing `react-nodegui` as a dependency. It will yield a
warning:
```
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: react-reconciler@0.25.1
npm WARN Found: react@17.0.2
npm WARN node_modules/react
npm WARN   react@"^17.0.2" from the root project
npm WARN   1 more (@nodegui/react-nodegui)
npm WARN
npm WARN Could not resolve dependency:
npm WARN peer react@"^16.13.1" from react-reconciler@0.25.1
npm WARN node_modules/react-reconciler
npm WARN   react-reconciler@"^0.25.1" from @nodegui/react-nodegui@0.13.0
npm WARN   node_modules/@nodegui/react-nodegui
npm WARN
npm WARN Conflicting peer dependency: react@16.14.0
npm WARN node_modules/react
npm WARN   peer react@"^16.13.1" from react-reconciler@0.25.1
npm WARN   node_modules/react-reconciler
npm WARN     react-reconciler@"^0.25.1" from @nodegui/react-nodegui@0.13.0
npm WARN     node_modules/@nodegui/react-nodegui
```